### PR TITLE
Align lease API route param names

### DIFF
--- a/src/app/api/leases/[leaseId]/route.ts
+++ b/src/app/api/leases/[leaseId]/route.ts
@@ -20,7 +20,7 @@ export async function PUT(request: NextRequest, { params }: { params: { leaseId:
     const { data: updated, error } = await supabase.from('lease').update(patch).eq('id', id).select().single()
     if (error) return NextResponse.json({ error: error.message }, { status: 400 })
 
-    let buildium: any = null
+    let buildium: Record<string, unknown> | null = null
     if (syncBuildium) {
       // Prepare Buildium payload; prefer direct fields if provided
       let PropertyId = updated.buildium_property_id
@@ -33,7 +33,21 @@ export async function PUT(request: NextRequest, { params }: { params: { leaseId:
         const { data: u } = await supabase.from('units').select('buildium_unit_id').eq('id', updated.unit_id).single()
         UnitId = u?.buildium_unit_id
       }
-      const payload: any = {
+      type BuildiumLeasePayload = {
+        PropertyId?: number | null
+        UnitId?: number | null
+        LeaseFromDate: string | null
+        LeaseToDate?: string | null
+        LeaseType: string
+        RenewalOfferStatus: string
+        CurrentNumberOfOccupants?: number | null
+        IsEvictionPending?: boolean | null
+        AutomaticallyMoveOutTenants?: boolean | null
+        PaymentDueDay?: number | null
+        AccountDetails: { Rent: number; SecurityDeposit: number }
+      }
+
+      const payload: BuildiumLeasePayload = {
         PropertyId,
         UnitId,
         LeaseFromDate: updated.lease_from_date,

--- a/src/app/api/leases/[leaseId]/route.ts
+++ b/src/app/api/leases/[leaseId]/route.ts
@@ -3,16 +3,16 @@ import { supabase } from '@/lib/db'
 import { buildiumEdgeClient } from '@/lib/buildium-edge-client'
 import { logger } from '@/lib/logger'
 
-export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
-  const id = Number(params.id)
+export async function GET(_req: NextRequest, { params }: { params: { leaseId: string } }) {
+  const id = Number(params.leaseId)
   const { data, error } = await supabase.from('lease').select('*').eq('id', id).single()
   if (error) return NextResponse.json({ error: error.message }, { status: 404 })
   return NextResponse.json(data)
 }
 
-export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
+export async function PUT(request: NextRequest, { params }: { params: { leaseId: string } }) {
   try {
-    const id = Number(params.id)
+    const id = Number(params.leaseId)
     const url = new URL(request.url)
     const syncBuildium = url.searchParams.get('syncBuildium') === 'true'
     const body = await request.json()


### PR DESCRIPTION
## Summary
- move the leases API handler into the existing `[leaseId]` folder so all dynamic routes share the same slug
- update the handler to read `params.leaseId`, matching the folder name

## Testing
- `npm run build` *(fails: Next.js cannot download Inter font files in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cce5b17e688321a66bf184eaaed58c